### PR TITLE
Configurable docker repo namespace

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,12 @@ ENV=production
 SPIRE_DEV=false
 
 ###########################################################
+# Container registry and namespace
+###########################################################
+REGISTRY=docker.io
+REGISTRY_NAMESPACE=akkadius
+
+###########################################################
 # Drivers
 ###########################################################
 VOLUMES_DRIVER=local

--- a/Makefile
+++ b/Makefile
@@ -77,22 +77,36 @@ ifneq ($(ip-address),)
 	 IN_IP_ADDRESS=$(ip-address)
 endif
 
+IN_REGISTRY=${REGISTRY}
+ifneq ($(registry),)
+         IN_REGISTRY=$(registry)
+endif
+
+IN_REGISTRY_NAMESPACE=${REGISTRY_NAMESPACE}
+ifneq ($(registry-namespace),)
+         IN_REGISTRY_NAMESPACE=$(registry-namespace)
+endif
+
 #----------------------
 # env
 #----------------------
 
-set-vars: ##@env Sets var port-range-high=[] ip-address=[]
+set-vars: ##@env Sets var port-range-high=[] ip-address=[] registry=[] registry-namespace=[]
 	@assets/scripts/env-set-var.pl IP_ADDRESS $(IN_IP_ADDRESS)
 	@assets/scripts/env-set-var.pl PORT_RANGE_HIGH $(IN_PORT_RANGE_HIGH)
+	@assets/scripts/env-set-var.pl REGISTRY ${IN_REGISTRY}
+	@assets/scripts/env-set-var.pl REGISTRY_NAMESPACE ${IN_REGISTRY_NAMESPACE}
 
 #----------------------
 # Init / Install
 #----------------------
 
-install: ##@init Install full application port-range-high=[] ip-address=[]
+install: ##@init Install full application port-range-high=[] ip-address=[] registry=[] registry-namespace[]
 	$(DOCKER) pull
 	@assets/scripts/env-set-var.pl IP_ADDRESS $(IN_IP_ADDRESS)
 	@assets/scripts/env-set-var.pl PORT_RANGE_HIGH $(IN_PORT_RANGE_HIGH)
+	@assets/scripts/env-set-var.pl REGISTRY ${IN_REGISTRY}
+	@assets/scripts/env-set-var.pl REGISTRY_NAMESPACE ${IN_REGISTRY_NAMESPACE}
 	$(DOCKER) build mariadb
 	make up detached
 	@assets/scripts/env-set-var.pl
@@ -138,35 +152,35 @@ image-build-push-all: ##@image-build Build and push all images
 # eqemu-server
 
 image-eqemu-server-build: ##@image-build Builds image
-	docker build containers/eqemu-server -t akkadius/eqemu-server:latest
-	docker build containers/eqemu-server -t akkadius/eqemu-server:v11
+	docker build containers/eqemu-server -t ${REGISTRY}/${REGISTRY_NAMESPACE}/eqemu-server:latest
+	docker build containers/eqemu-server -t ${REGISTRY}/${REGISTRY_NAMESPACE}/eqemu-server:v11
 
 image-eqemu-server-build-dev: ##@image-build Builds image (development)
 	make image-eqemu-server-build
-	docker build -f ./containers/eqemu-server/dev.dockerfile ./containers/eqemu-server -t akkadius/eqemu-server:v11-dev
+	docker build -f ./containers/eqemu-server/dev.dockerfile ./containers/eqemu-server -t ${REGISTRY}/${REGISTRY_NAMESPACE}/eqemu-server:v11-dev
 
 image-eqemu-server-push: ##@image-build Publishes image
-	docker push akkadius/eqemu-server:latest
-	docker push akkadius/eqemu-server:v11
+	docker push ${REGISTRY}/${REGISTRY_NAMESPACE}/eqemu-server:latest
+	docker push ${REGISTRY}/${REGISTRY_NAMESPACE}/eqemu-server:v11
 
 image-eqemu-server-push-dev: ##@image-build Publishes image
-	docker push akkadius/eqemu-server:v11-dev
+	docker push ${REGISTRY}/${REGISTRY_NAMESPACE}/eqemu-server:v11-dev
 
 # peq-editor
 
 image-peq-editor-build: ##@image-build Builds image
-	docker build containers/peq-editor -t akkadius/peq-editor:latest
+	docker build containers/peq-editor -t ${REGISTRY}/${REGISTRY_NAMESPACE}/peq-editor:latest
 
 image-peq-editor-push: ##@image-build Publishes image
-	docker push akkadius/peq-editor:latest
+	docker push ${REGISTRY}/${REGISTRY_NAMESPACE}/peq-editor:latest
 
 # backup-cron
 
 image-backup-cron-build: ##@image-build Builds image
-	docker build containers/backup-cron -t akkadius/eqemu-backup-cron:latest
+	docker build containers/backup-cron -t ${REGISTRY}/${REGISTRY_NAMESPACE}/eqemu-backup-cron:latest
 
 image-backup-cron-push: ##@image-build Publishes image
-	docker push akkadius/eqemu-backup-cron:latest
+	docker push ${REGISTRY}/${REGISTRY_NAMESPACE}/eqemu-backup-cron:latest
 
 #----------------------
 # Workflow

--- a/README.md
+++ b/README.md
@@ -632,6 +632,23 @@ If you are trying to be accessible from WAN, you will need to set
 
 This address is used for the **loginserver** you host yourself as well
 
+# Customizing
+
+## Changing Docker the repository
+
+In case you want to build and run on customized docker containers you can change the docker repository and namespace.
+
+```
+root@host:/opt/eqemu-servers# make set-vars registry-namespace=mynamespace container registry=mydockerrepo
+Wrote [REGISTRY] = [mydockerrepo] to [.env]
+Wrote [REGISTRY_NAMESPACE] = [mynamespace] to [.env]
+```
+
+Don't forget to create the containers afterwards.
+
+```
+root@host:/opt/eqemu-servers# make image-build-push-all
+```
 # Troubleshooting
 
 ## Networking

--- a/README.md
+++ b/README.md
@@ -634,9 +634,9 @@ This address is used for the **loginserver** you host yourself as well
 
 # Customizing
 
-## Changing Docker the repository
+## Changing the Docker repository
 
-In case you want to build and run on customized docker containers you can change the docker repository and namespace.
+In case you want to build and run on customized docker containers you can set another docker repository and namespace.
 
 ```
 root@host:/opt/eqemu-servers# make set-vars registry-namespace=mynamespace container registry=mydockerrepo
@@ -644,11 +644,12 @@ Wrote [REGISTRY] = [mydockerrepo] to [.env]
 Wrote [REGISTRY_NAMESPACE] = [mynamespace] to [.env]
 ```
 
-Don't forget to create the containers afterwards.
+Don't forget to create and push the containers afterwards.
 
 ```
 root@host:/opt/eqemu-servers# make image-build-push-all
 ```
+
 # Troubleshooting
 
 ## Networking

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
 
   eqemu-server:
     restart: unless-stopped
-    image: akkadius/eqemu-server:v11
+    image: ${REGISTRY}/${REGISTRY_NAMESPACE}/eqemu-server:v11
     volumes:
       - ./server:/home/eqemu/server:delegated
       - ./code:/home/eqemu/code:delegated
@@ -113,7 +113,7 @@ services:
   #############################################
 
   peq-editor:
-    image: akkadius/peq-editor:latest
+    image: ${REGISTRY}/${REGISTRY_NAMESPACE}/peq-editor:latest
     restart: unless-stopped
     ports:
       - ${IP_ADDRESS}:8081:80
@@ -159,7 +159,7 @@ services:
 
   backup-cron:
     restart: unless-stopped
-    image: akkadius/eqemu-backup-cron:latest
+    image: ${REGISTRY}/${REGISTRY_NAMESPACE}/eqemu-backup-cron:latest
     build:
       context: ./containers/backup-cron
     hostname: backup-cron


### PR DESCRIPTION
Added options to push/pull docker containers to/from another repository than the default.

One question here: Originally I also wanted to add the option `container-tag`. Since your switch to Debian 11 you altered the `Makefile` and `docker-compose.yml`.  Now the main `Makefile` pushes two tags for eqemu-server `:latest` and `:v11` while `docker-compose.yml` only pulls `:v11`. Will `:latest` be removed in an upcoming update?