### PR TITLE
correct pypmyadmin image, change nginx to mainline

### DIFF
--- a/containers/http-proxy/Dockerfile
+++ b/containers/http-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.11.9-alpine
+FROM nginx:mainline-alpine
 
 # for htpasswd command
 RUN apk add --no-cache --update apache2-utils

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,7 @@ services:
 
   phpmyadmin:
     restart: unless-stopped
-    image: phpmyadmin/phpmyadmin:latest
+    image: phpmyadmin:latest
     environment:
       - PMA_HOST=mariadb
       - PMA_USER=${MARIADB_USER}


### PR DESCRIPTION
nginx: changed from a very old fixed version to mainline. Comfirmed it's working
phpmyadmin: Switched to the offical docker repository. the old is maintained as a courtesy to users who have not migrated yet. 
New PR because I was dumb and deleted my fork prematurely