### PR TITLE
[Feature] Add configurable services in .env to be booted

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,15 @@ ENV=production
 SPIRE_DEV=false
 
 ###########################################################
+# Services
+###########################################################
+# enables the services to be started
+ENABLE_BACKUP_CRON=false
+ENABLE_FTP_QUESTS=false
+ENABLE_PEQ_EDITOR=false
+ENABLE_PHPMYADMIN=false
+
+###########################################################
 # Drivers
 ###########################################################
 VOLUMES_DRIVER=local

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,27 @@ ifneq ($(ip-address),)
 endif
 
 #----------------------
+# services
+#----------------------
+
+RUN_SERVICES=
+ifeq ($(ENABLE_FTP_QUESTS),true)
+	RUN_SERVICES+= ftp-quests
+endif
+
+ifeq ($(ENABLE_PHPMYADMIN),true)
+	RUN_SERVICES+= phpmyadmin
+endif
+
+ifeq ($(ENABLE_PEQ_EDITOR),true)
+	RUN_SERVICES+= peq-editor
+endif
+
+ifeq ($(ENABLE_BACKUP_CRON),true)
+	RUN_SERVICES+= backup-cron
+endif
+
+#----------------------
 # env
 #----------------------
 
@@ -199,7 +220,7 @@ watch-processes: ##@workflow Watch processes
 #----------------------
 
 up: ##@docker Bring up eqemu-server and database
-	COMPOSE_HTTP_TIMEOUT=1000 $(DOCKER) up -d eqemu-server mariadb
+	COMPOSE_HTTP_TIMEOUT=1000 $(DOCKER) up -d eqemu-server mariadb $(RUN_SERVICES)
 	make up-info
 
 down: ##@docker Down all containers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,8 @@ services:
       - backend
 
   phpmyadmin:
+    depends_on:
+      - phpmyadmin-proxy
     restart: unless-stopped
     image: phpmyadmin/phpmyadmin:latest
     environment:


### PR DESCRIPTION
This PR adds the ability to selectively boot additional services using `make up`

`eqemu-server` and `mariadb` are core / required services that are always booted, but an operator may want to include more

**.env**

```
###########################################################
# Services
###########################################################
# enables the services to be started
ENABLE_BACKUP_CRON=false
ENABLE_FTP_QUESTS=false
ENABLE_PEQ_EDITOR=false
ENABLE_PHPMYADMIN=false
```