### PR TITLE
Install Tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ env-scramble-secrets: ##@env Scrambles secrets
 env-set-zone-port-range-high: ##@env Set zone port range high value
 	$(DOCKER) up -d eqemu-server
 	@assets/scripts/env-set-var.pl PORT_RANGE_HIGH $(RUN_ARGS)
-	$(DOCKER) exec eqemu-server bash -c "cat ~/server/eqemu_config.json | jq '.server.zones.ports.high = "${PORT_RANGE_HIGH}"' -M > ~/server/eqemu_config.json"
+	$(DOCKER) exec eqemu-server bash -c "cat ~/server/eqemu_config.json | jq '.server.zones.ports.high = "${PORT_RANGE_HIGH}"' -M > /tmp/config.json && mv /tmp/config.json ~/server/eqemu_config.json && rm -f /tmp/config.json"
 	$(DOCKER) up -d --force-recreate eqemu-server
 
 #----------------------

--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ env-scramble-secrets: ##@env Scrambles secrets
 env-set-zone-port-range-high: ##@env Set zone port range high value
 	$(DOCKER) up -d eqemu-server
 	@assets/scripts/env-set-var.pl PORT_RANGE_HIGH $(RUN_ARGS)
-	$(DOCKER) exec eqemu-server bash -c "cat ~/server/eqemu_config.json | jq '.server.zones.ports.high = "${PORT_RANGE_HIGH}"' -M ~/server/eqemu_config.json"
+	$(DOCKER) exec eqemu-server bash -c "cat ~/server/eqemu_config.json | jq '.server.zones.ports.high = "${PORT_RANGE_HIGH}"' | tee ~/server/eqemu_config.json"
 	$(DOCKER) up -d --force-recreate eqemu-server
 
 #----------------------

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ install: ##@init Install full application port-range-high=[] ip-address=[]
 	@assets/scripts/env-set-var.pl
 	$(DOCKER) exec mariadb bash -c 'while ! mysqladmin status -uroot -p${MARIADB_ROOT_PASSWORD} -h "localhost" --silent; do sleep .5; done; sleep 5'
 	make init-strip-mysql-remote-root
-	$(DOCKER) exec -T eqemu-server bash -c "make install"
+	$(DOCKER) exec eqemu-server bash -c "make install"
 	make init-peq-editor
 	COMPOSE_HTTP_TIMEOUT=1000 $(DOCKER) down --timeout 3
 	COMPOSE_HTTP_TIMEOUT=1000 $(DOCKER) up -d
@@ -243,7 +243,7 @@ env-scramble-secrets: ##@env Scrambles secrets
 env-set-zone-port-range-high: ##@env Set zone port range high value
 	$(DOCKER) up -d eqemu-server
 	@assets/scripts/env-set-var.pl PORT_RANGE_HIGH $(RUN_ARGS)
-	$(DOCKER) exec eqemu-server bash -c "cat ~/server/eqemu_config.json | jq '.server.zones.ports.high = "${PORT_RANGE_HIGH}"' | tee ~/server/eqemu_config.json"
+	$(DOCKER) exec eqemu-server bash -c "cat ~/server/eqemu_config.json | jq '.server.zones.ports.high = "${PORT_RANGE_HIGH}"' -M > ~/server/eqemu_config.json"
 	$(DOCKER) up -d --force-recreate eqemu-server
 
 #----------------------

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ install: ##@init Install full application port-range-high=[] ip-address=[]
 	@assets/scripts/env-set-var.pl
 	$(DOCKER) exec mariadb bash -c 'while ! mysqladmin status -uroot -p${MARIADB_ROOT_PASSWORD} -h "localhost" --silent; do sleep .5; done; sleep 5'
 	make init-strip-mysql-remote-root
-	$(DOCKER) exec eqemu-server bash -c "make install"
+	$(DOCKER) exec -T eqemu-server bash -c "make install"
 	make init-peq-editor
 	COMPOSE_HTTP_TIMEOUT=1000 $(DOCKER) down --timeout 3
 	COMPOSE_HTTP_TIMEOUT=1000 $(DOCKER) up -d

--- a/Makefile
+++ b/Makefile
@@ -121,8 +121,8 @@ install: ##@init Install full application port-range-high=[] ip-address=[]
 	make init-strip-mysql-remote-root
 	$(DOCKER) exec -T eqemu-server bash -c "make install"
 	make init-peq-editor
-	COMPOSE_HTTP_TIMEOUT=1000 $(DOCKER) down --timeout 3
-	COMPOSE_HTTP_TIMEOUT=1000 $(DOCKER) up -d
+	make down
+	make up
 	make up-info
 
 init-strip-mysql-remote-root: ##@init Strips MySQL remote root user

--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ env-scramble-secrets: ##@env Scrambles secrets
 env-set-zone-port-range-high: ##@env Set zone port range high value
 	$(DOCKER) up -d eqemu-server
 	@assets/scripts/env-set-var.pl PORT_RANGE_HIGH $(RUN_ARGS)
-	$(DOCKER) exec eqemu-server bash -c "cat ~/server/eqemu_config.json | jq '.server.zones.ports.high = "${PORT_RANGE_HIGH}"' | tee ~/server/eqemu_config.json"
+	$(DOCKER) exec eqemu-server bash -c "cat ~/server/eqemu_config.json | jq '.server.zones.ports.high = "${PORT_RANGE_HIGH}"' -M ~/server/eqemu_config.json"
 	$(DOCKER) up -d --force-recreate eqemu-server
 
 #----------------------

--- a/assets/scripts/Makefile
+++ b/assets/scripts/Makefile
@@ -154,7 +154,7 @@ init-eqemu-admin-assets: ##@init Initializes EQEmu Admin Assets
 init-eqemu-admin: ##@init Initializes EQEmu Admin
 	rm -f ~/server/bin/eqemu-admin-*
 	rm -f ~/server/bin/spire-*
-	wget --progress=bar:force:noscroll --quiet $(shell curl -s https://api.github.com/repos/Akkadius/spire/releases/latest | jq -r '.assets[].browser_download_url' | grep spire-linux) -O /tmp/spire.zip
+	wget --progress=bar:force:noscroll --quiet https://github.com/akkadius/spire/releases/latest/download/spire-linux-amd64.zip -O /tmp/spire.zip
 	unzip -o /tmp/spire.zip -d ~/server/bin
 	mv ~/server/bin/spire-linux-amd64 ~/server/bin/spire
 	chmod +x ~/server/bin/spire

--- a/assets/scripts/Makefile
+++ b/assets/scripts/Makefile
@@ -85,14 +85,12 @@ init-shared-memory: ##@init Run shared memory once on initial install
 init-eqemu-config: ##@init Bootstraps eqemu config
 	@./assets/scripts/banner.pl "Initializing EQEmu Config"
 	@make pull-docker-config
-	jq --arg dbpass "$(EQEMU_DB_PASSWORD)" \
-	   --arg porthigh "$(PORT_RANGE_HIGH)" \
-	   --arg ipaddr "$(IP_ADDRESS)" \
-	   '.server.database.password = $$dbpass | \
-		.server.world.key = (input_filename | capture("(?<prefix>.*)(?<suffix>.json)"; "i").prefix + ("/dev/urandom" | getline | strflocaltime("%Y%m%d%H%M%S"))) | \
-		.server.zones.ports.high = $$porthigh | \
-		.server.world.address = $$ipaddr | \
-        .server.ucs.host = $ipaddr' ~/server/eqemu_config.json > temp.json && mv temp.json ~/server/eqemu_config.json
+	@cat ~/server/eqemu_config.json \
+        | jq --arg dbpass "$(EQEMU_DB_PASSWORD)" '.server.database.password = $$dbpass' \
+        | jq --arg ipaddr "$(IP_ADDRESS)" '.server.world.address = $$ipaddr | .server.ucs.host = $$ipaddr' \
+        | jq '.server.zones.ports.high = "$(PORT_RANGE_HIGH)"' \
+        | jq '.server.world.key = (input_filename | capture("(?<prefix>.*)(?<suffix>.json)"; "i").prefix + ("/dev/urandom" | getline | strflocaltime("%Y%m%d%H%M%S")))' \
+        | tee ~/server/eqemu_config.json > /dev/null
 
 init-directories: ##@init Bootstrap directories
 	@./assets/scripts/banner.pl "Bootstrapping directories"
@@ -166,7 +164,7 @@ init-eqemu-admin: ##@init Initializes EQEmu Admin
 		| jq '.["web-admin"].launcher.runSharedMemory = true' \
 		| jq '.["web-admin"].launcher.minZoneProcesses = 10' \
 		| jq '.["web-admin"].launcher.staticZones = "butcher,erudnext,freporte,qeynos,freeporte,oot,iceclad,nro,oasis,nedaria,abysmal,natimbi,timorous,abysmal,firiona,overthere"' \
-		-M > ~/server/eqemu_config.json
+		| tee ~/server/eqemu_config.json
 	cd ~/server && ./bin/spire spire:init admin ${ADMIN_PASSWORD} || echo "Already initialized"
 	cd ~/server && ./bin/spire spire:occulus-update
 
@@ -177,12 +175,12 @@ init-eqemu-admin-dev: ##@init Initializes EQEmu Admin (Development)
 	cd ~/server/eqemu-web-admin/frontend && npm install
 
 init-peq-editor: ##@init Initializes PEQ Editor DB tables
-	wget --quiet https://raw.githubusercontent.com/ProjectEQ/peqphpeditor/master/sql/schema.sql -O /tmp/schema.sql
-	mysql -u$(shell ~/assets/scripts/init/get-config-var.sh '.server.database.username') \
+	@wget --quiet https://raw.githubusercontent.com/ProjectEQ/peqphpeditor/master/sql/schema.sql -O /tmp/schema.sql
+	@mysql -u$(shell ~/assets/scripts/init/get-config-var.sh '.server.database.username') \
     		-p$(shell ~/assets/scripts/init/get-config-var.sh '.server.database.password') \
     		-h $(shell ~/assets/scripts/init/get-config-var.sh '.server.database.host') \
     		$(shell ~/assets/scripts/init/get-config-var.sh '.server.database.db') < /tmp/schema.sql
-	mysql -u$(shell ~/assets/scripts/init/get-config-var.sh '.server.database.username') \
+	@mysql -u$(shell ~/assets/scripts/init/get-config-var.sh '.server.database.username') \
     		-p$(shell ~/assets/scripts/init/get-config-var.sh '.server.database.password') \
     		-h $(shell ~/assets/scripts/init/get-config-var.sh '.server.database.host') \
     		$(shell ~/assets/scripts/init/get-config-var.sh '.server.database.db') -e 'update peq_admin SET password = MD5("${PEQ_EDITOR_PASSWORD}") where id = 1'

--- a/assets/scripts/Makefile
+++ b/assets/scripts/Makefile
@@ -89,7 +89,7 @@ init-eqemu-config: ##@init Bootstraps eqemu config
              | jq --arg dbpass "$(EQEMU_DB_PASSWORD)" '.server.database.password = $$dbpass' \
              | jq --arg ipaddr "$(IP_ADDRESS)" '.server.world.address = $$ipaddr | .server.ucs.host = $$ipaddr' \
              | jq --arg porthigh "$(PORT_RANGE_HIGH)" '.server.zones.ports.high = $$porthigh' \
-             | jq --arg random_string "$(shell cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w $${1:-32} | head -n 1)" '.server.world.key = $$random_string' \
+             | jq --arg random_string "$$(openssl rand -base64 32 | tr -dc 'a-zA-Z0-9' | head -c 32)" '.server.world.key = $$random_string' \
              | tee ~/server/eqemu_config.json > /dev/null
 
 init-directories: ##@init Bootstrap directories

--- a/assets/scripts/Makefile
+++ b/assets/scripts/Makefile
@@ -150,10 +150,10 @@ init-eqemu-admin-assets: ##@init Initializes EQEmu Admin Assets
 		echo "spire assets are initialized"; \
 	else \
 		echo "spire assets are not initialized"; \
-		curl -L https://github.com/Akkadius/eq-asset-preview/releases/latest/download/build.zip -o /tmp/build.zip && \
-		mkdir -p ~/.cache/spire && \
-		mkdir -p ~/.cache/spire/assets && \
-		unzip -o /tmp/build.zip -d ~/.cache/spire/assets \
+		curl -L https://github.com/Akkadius/eq-asset-preview/releases/latest/download/build.zip -o /tmp/build.zip; \
+		mkdir -p ~/.cache/spire; \
+		mkdir -p ~/.cache/spire/assets; \
+		unzip -o /tmp/build.zip -d ~/.cache/spire/assets; \
 	fi
 
 init-eqemu-admin: ##@init Initializes EQEmu Admin

--- a/assets/scripts/Makefile
+++ b/assets/scripts/Makefile
@@ -91,7 +91,7 @@ init-eqemu-config: ##@init Bootstraps eqemu config
     		| jq '.server.zones.ports.high = "${PORT_RANGE_HIGH}"' \
     		| jq '.server.world.address = "${IP_ADDRESS}"' \
     		| jq '.server.ucs.host = "${IP_ADDRESS}"' \
-    		-M ~/server/eqemu_config.json
+    		| tee ~/server/eqemu_config.json
 
 init-directories: ##@init Bootstrap directories
 	@./assets/scripts/banner.pl "Bootstrapping directories"
@@ -165,7 +165,7 @@ init-eqemu-admin: ##@init Initializes EQEmu Admin
 		| jq '.["web-admin"].launcher.runSharedMemory = true' \
 		| jq '.["web-admin"].launcher.minZoneProcesses = 10' \
 		| jq '.["web-admin"].launcher.staticZones = "butcher,erudnext,freporte,qeynos,freeporte,oot,iceclad,nro,oasis,nedaria,abysmal,natimbi,timorous,abysmal,firiona,overthere"' \
-		-M ~/server/eqemu_config.json
+		| tee ~/server/eqemu_config.json
 	cd ~/server && ./bin/spire spire:init admin ${ADMIN_PASSWORD} || echo "Already initialized"
 	cd ~/server && ./bin/spire spire:occulus-update
 

--- a/assets/scripts/Makefile
+++ b/assets/scripts/Makefile
@@ -146,10 +146,15 @@ endif
 
 init-eqemu-admin-assets: ##@init Initializes EQEmu Admin Assets
 	@./assets/scripts/banner.pl "Initializing EQEmu Admin Assets"
-	curl -L https://github.com/Akkadius/eq-asset-preview/releases/latest/download/build.zip -o /tmp/build.zip
-	mkdir -p ~/.cache/spire
-	mkdir -p ~/.cache/spire/assets
-	unzip -o /tmp/build.zip -d ~/.cache/spire/assets
+	@if [ $(shell find ~/.cache/spire/assets/assets | wc -l) -gt 10 ] ; then \
+		echo "spire assets are initialized"; \
+	else \
+		echo "spire assets are not initialized"; \
+		curl -L https://github.com/Akkadius/eq-asset-preview/releases/latest/download/build.zip -o /tmp/build.zip && \
+		mkdir -p ~/.cache/spire && \
+		mkdir -p ~/.cache/spire/assets && \
+		unzip -o /tmp/build.zip -d ~/.cache/spire/assets \
+	fi
 
 init-eqemu-admin: ##@init Initializes EQEmu Admin
 	rm -f ~/server/bin/eqemu-admin-*

--- a/assets/scripts/Makefile
+++ b/assets/scripts/Makefile
@@ -90,7 +90,7 @@ init-eqemu-config: ##@init Bootstraps eqemu config
              | jq --arg ipaddr "$(IP_ADDRESS)" '.server.world.address = $$ipaddr | .server.ucs.host = $$ipaddr' \
              | jq --arg porthigh "$(PORT_RANGE_HIGH)" '.server.zones.ports.high = $$porthigh' \
              | jq --arg random_string "$$(openssl rand -base64 32 | tr -dc 'a-zA-Z0-9' | head -c 32)" '.server.world.key = $$random_string' \
-             | tee ~/server/eqemu_config.json > /dev/null
+             -M /tmp/config.json && mv /tmp/config.json ~/server/eqemu_config.json
 
 init-directories: ##@init Bootstrap directories
 	@./assets/scripts/banner.pl "Bootstrapping directories"

--- a/assets/scripts/Makefile
+++ b/assets/scripts/Makefile
@@ -226,7 +226,7 @@ pull-maps: ##@assets Pulls maps
 		echo "maps is initialized"; \
 	else \
 		echo "maps is not initialized"; \
-		cd server && wget --progress=bar:force:noscroll https://github.com/Akkadius/eqemu-maps/releases/latest/download/maps.zip -O /tmp/maps.zip && unzip -o /tmp/maps.zip -d ~/server/maps && rm /tmp/maps.zip; \
+		cd server && wget --progress=bar:force:noscroll https://github.com/Akkadius/eqemu-maps/releases/latest/download/maps.zip -O /tmp/maps.zip && unzip -o /tmp/maps.zip -d ~/server/maps && rm /tmp/maps.zip || true; \
 	fi
 
 pull-eqemu-code: ##@assets Pulls eqemu code

--- a/assets/scripts/Makefile
+++ b/assets/scripts/Makefile
@@ -89,7 +89,7 @@ init-eqemu-config: ##@init Bootstraps eqemu config
              | jq --arg dbpass "$(EQEMU_DB_PASSWORD)" '.server.database.password = $$dbpass' \
              | jq --arg ipaddr "$(IP_ADDRESS)" '.server.world.address = $$ipaddr | .server.ucs.host = $$ipaddr' \
              | jq --arg porthigh "$(PORT_RANGE_HIGH)" '.server.zones.ports.high = $$porthigh' \
-             | jq --argjson random_string "$$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w $${1:-32} | head -n 1)" '.server.world.key = $$random_string' \
+             | jq --arg random_string "$(shell cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w $${1:-32} | head -n 1)" '.server.world.key = $$random_string' \
              | tee ~/server/eqemu_config.json > /dev/null
 
 init-directories: ##@init Bootstrap directories

--- a/assets/scripts/Makefile
+++ b/assets/scripts/Makefile
@@ -90,7 +90,7 @@ init-eqemu-config: ##@init Bootstraps eqemu config
              | jq --arg ipaddr "$(IP_ADDRESS)" '.server.world.address = $$ipaddr | .server.ucs.host = $$ipaddr' \
              | jq --arg porthigh "$(PORT_RANGE_HIGH)" '.server.zones.ports.high = $$porthigh' \
              | jq --arg random_string "$$(openssl rand -base64 32 | tr -dc 'a-zA-Z0-9' | head -c 32)" '.server.world.key = $$random_string' \
-             -M /tmp/config.json && mv /tmp/config.json ~/server/eqemu_config.json
+             -M > /tmp/config.json && mv /tmp/config.json ~/server/eqemu_config.json
 
 init-directories: ##@init Bootstrap directories
 	@./assets/scripts/banner.pl "Bootstrapping directories"

--- a/assets/scripts/Makefile
+++ b/assets/scripts/Makefile
@@ -153,7 +153,7 @@ init-eqemu-admin-assets: ##@init Initializes EQEmu Admin Assets
 init-eqemu-admin: ##@init Initializes EQEmu Admin
 	rm -f ~/server/bin/eqemu-admin-*
 	rm -f ~/server/bin/spire-*
-	wget --quiet $(shell curl -s https://api.github.com/repos/Akkadius/spire/releases/latest | jq -r '.assets[].browser_download_url' | grep spire-linux) -O /tmp/spire.zip
+	wget --progress=bar:force:noscroll --quiet $(shell curl -s https://api.github.com/repos/Akkadius/spire/releases/latest | jq -r '.assets[].browser_download_url' | grep spire-linux) -O /tmp/spire.zip
 	unzip -o /tmp/spire.zip -d ~/server/bin
 	mv ~/server/bin/spire-linux-amd64 ~/server/bin/spire
 	chmod +x ~/server/bin/spire
@@ -239,7 +239,7 @@ pull-peq-quests: ##@assets Pulls ProjectEQ quests
 
 pull-docker-config: ##@assets Pulls default eqemu_config.json
 	@./assets/scripts/banner.pl "Bootstrapping default [eqemu_config.json]"
-	cd ~/server && wget --no-cache --no-check-certificate --no-cookies https://raw.githubusercontent.com/Akkadius/eqemu-install-v2/master/eqemu_config_docker.json -O eqemu_config.json
+	cd ~/server && wget --progress=bar:force:noscroll --no-cache --no-check-certificate --no-cookies https://raw.githubusercontent.com/Akkadius/eqemu-install-v2/master/eqemu_config_docker.json -O eqemu_config.json
 
 #----------------------
 # mgmt
@@ -308,7 +308,7 @@ endif
 update-admin-panel: ##@update Update admin panel
 	kill $(shell ps aux | grep "eqemu-admin" | grep "web" | grep -v "grep" | awk '{print $$2}' | tr '\n' ' ') &>/dev/null || echo "Nothing to kill"
 	kill $(shell ps aux | grep "spire" | grep "http:serve" | grep -v "grep" | awk '{print $$2}' | tr '\n' ' ') &>/dev/null || echo "Nothing to kill"
-	wget --quiet $(shell curl -s https://api.github.com/repos/Akkadius/spire/releases/latest | jq -r '.assets[].browser_download_url' | grep spire-linux) -O /tmp/spire.zip
+	wget --progress=bar:force:noscroll --quiet $(shell curl -s https://api.github.com/repos/Akkadius/spire/releases/latest | jq -r '.assets[].browser_download_url' | grep spire-linux) -O /tmp/spire.zip
 	unzip -o /tmp/spire.zip -d ~/server/bin
 	mv ~/server/bin/spire-linux-amd64 ~/server/bin/spire
 	chmod +x ~/server/bin/spire

--- a/assets/scripts/Makefile
+++ b/assets/scripts/Makefile
@@ -91,7 +91,7 @@ init-eqemu-config: ##@init Bootstraps eqemu config
     		| jq '.server.zones.ports.high = "${PORT_RANGE_HIGH}"' \
     		| jq '.server.world.address = "${IP_ADDRESS}"' \
     		| jq '.server.ucs.host = "${IP_ADDRESS}"' \
-    		| tee ~/server/eqemu_config.json
+    		-M ~/server/eqemu_config.json
 
 init-directories: ##@init Bootstrap directories
 	@./assets/scripts/banner.pl "Bootstrapping directories"
@@ -165,7 +165,7 @@ init-eqemu-admin: ##@init Initializes EQEmu Admin
 		| jq '.["web-admin"].launcher.runSharedMemory = true' \
 		| jq '.["web-admin"].launcher.minZoneProcesses = 10' \
 		| jq '.["web-admin"].launcher.staticZones = "butcher,erudnext,freporte,qeynos,freeporte,oot,iceclad,nro,oasis,nedaria,abysmal,natimbi,timorous,abysmal,firiona,overthere"' \
-		| tee ~/server/eqemu_config.json
+		-M ~/server/eqemu_config.json
 	cd ~/server && ./bin/spire spire:init admin ${ADMIN_PASSWORD} || echo "Already initialized"
 	cd ~/server && ./bin/spire spire:occulus-update
 

--- a/assets/scripts/Makefile
+++ b/assets/scripts/Makefile
@@ -86,12 +86,12 @@ init-eqemu-config: ##@init Bootstraps eqemu config
 	@./assets/scripts/banner.pl "Initializing EQEmu Config"
 	@make pull-docker-config
 	@cat ~/server/eqemu_config.json \
-    		| jq '.server.database.password = "${EQEMU_DB_PASSWORD}"' \
-    		| jq '.server.world.key = "$(shell cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w $${1:-32} | head -n 1)"' \
-    		| jq '.server.zones.ports.high = "${PORT_RANGE_HIGH}"' \
-    		| jq '.server.world.address = "${IP_ADDRESS}"' \
-    		| jq '.server.ucs.host = "${IP_ADDRESS}"' \
-    		| tee ~/server/eqemu_config.json
+         | jq ".server.database.password = \"${EQEMU_DB_PASSWORD}\"" \
+         | jq ".server.world.key = \"$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w ${1:-32} | head -n 1)\"" \
+         | jq ".server.zones.ports.high = \"${PORT_RANGE_HIGH}\"" \
+         | jq ".server.world.address = \"${IP_ADDRESS}\"" \
+         | jq ".server.ucs.host = \"${IP_ADDRESS}\"" \
+         | tee ~/server/eqemu_config.json
 
 init-directories: ##@init Bootstrap directories
 	@./assets/scripts/banner.pl "Bootstrapping directories"

--- a/assets/scripts/Makefile
+++ b/assets/scripts/Makefile
@@ -226,7 +226,7 @@ pull-maps: ##@assets Pulls maps
 		echo "maps is initialized"; \
 	else \
 		echo "maps is not initialized"; \
-		cd server && wget https://github.com/Akkadius/eqemu-maps/releases/latest/download/maps.zip -O /tmp/maps.zip && unzip -o /tmp/maps.zip -d ~/server/maps && rm /tmp/maps.zip; \
+		cd server && wget --progress=bar:force:noscroll https://github.com/Akkadius/eqemu-maps/releases/latest/download/maps.zip -O /tmp/maps.zip && unzip -o /tmp/maps.zip -d ~/server/maps && rm /tmp/maps.zip; \
 	fi
 
 pull-eqemu-code: ##@assets Pulls eqemu code

--- a/assets/scripts/Makefile
+++ b/assets/scripts/Makefile
@@ -85,13 +85,14 @@ init-shared-memory: ##@init Run shared memory once on initial install
 init-eqemu-config: ##@init Bootstraps eqemu config
 	@./assets/scripts/banner.pl "Initializing EQEmu Config"
 	@make pull-docker-config
-	@cat ~/server/eqemu_config.json \
-    		| jq '.server.database.password = "${EQEMU_DB_PASSWORD}"' \
-    		| jq '.server.world.key = "$(shell cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w $${1:-32} | head -n 1)"' \
-    		| jq '.server.zones.ports.high = "${PORT_RANGE_HIGH}"' \
-    		| jq '.server.world.address = "${IP_ADDRESS}"' \
-    		| jq '.server.ucs.host = "${IP_ADDRESS}"' \
-    		-M > ~/server/eqemu_config.json
+	jq --arg dbpass "$(EQEMU_DB_PASSWORD)" \
+	   --arg porthigh "$(PORT_RANGE_HIGH)" \
+	   --arg ipaddr "$(IP_ADDRESS)" \
+	   '.server.database.password = $$dbpass |
+		.server.world.key = (input_filename | capture("(?<prefix>.*)(?<suffix>.json)"; "i").prefix + ("/dev/urandom" | getline | strflocaltime("%Y%m%d%H%M%S"))) |
+		.server.zones.ports.high = $$porthigh |
+		.server.world.address = $$ipaddr |
+        .server.ucs.host = $ipaddr' ~/server/eqemu_config.json > temp.json && mv temp.json ~/server/eqemu_config.json
 
 init-directories: ##@init Bootstrap directories
 	@./assets/scripts/banner.pl "Bootstrapping directories"

--- a/assets/scripts/Makefile
+++ b/assets/scripts/Makefile
@@ -94,6 +94,7 @@ init-eqemu-config: ##@init Bootstraps eqemu config
 
 init-directories: ##@init Bootstrap directories
 	@./assets/scripts/banner.pl "Bootstrapping directories"
+	sudo chown eqemu:eqemu ~/.cache -R
 	sudo chown eqemu:eqemu ~/server -R
 	sudo chown eqemu:eqemu ~/code -R
 	mkdir -p ~/server/assets

--- a/assets/scripts/Makefile
+++ b/assets/scripts/Makefile
@@ -86,11 +86,11 @@ init-eqemu-config: ##@init Bootstraps eqemu config
 	@./assets/scripts/banner.pl "Initializing EQEmu Config"
 	@make pull-docker-config
 	@cat ~/server/eqemu_config.json \
-        | jq --arg dbpass "$(EQEMU_DB_PASSWORD)" '.server.database.password = $$dbpass' \
-        | jq --arg ipaddr "$(IP_ADDRESS)" '.server.world.address = $$ipaddr | .server.ucs.host = $$ipaddr' \
-        | jq '.server.zones.ports.high = "$(PORT_RANGE_HIGH)"' \
-        | jq '.server.world.key = (input_filename | capture("(?<prefix>.*)(?<suffix>.json)"; "i").prefix + ("/dev/urandom" | getline | strflocaltime("%Y%m%d%H%M%S")))' \
-        | tee ~/server/eqemu_config.json > /dev/null
+             | jq --arg dbpass "$(EQEMU_DB_PASSWORD)" '.server.database.password = $$dbpass' \
+             | jq --arg ipaddr "$(IP_ADDRESS)" '.server.world.address = $$ipaddr | .server.ucs.host = $$ipaddr' \
+             | jq --arg porthigh "$(PORT_RANGE_HIGH)" '.server.zones.ports.high = $$porthigh' \
+             | jq --argjson random_string "$$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w $${1:-32} | head -n 1)" '.server.world.key = $$random_string' \
+             | tee ~/server/eqemu_config.json > /dev/null
 
 init-directories: ##@init Bootstrap directories
 	@./assets/scripts/banner.pl "Bootstrapping directories"

--- a/assets/scripts/Makefile
+++ b/assets/scripts/Makefile
@@ -86,12 +86,12 @@ init-eqemu-config: ##@init Bootstraps eqemu config
 	@./assets/scripts/banner.pl "Initializing EQEmu Config"
 	@make pull-docker-config
 	@cat ~/server/eqemu_config.json \
-         | jq ".server.database.password = \"${EQEMU_DB_PASSWORD}\"" \
-         | jq ".server.world.key = \"$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w ${1:-32} | head -n 1)\"" \
-         | jq ".server.zones.ports.high = \"${PORT_RANGE_HIGH}\"" \
-         | jq ".server.world.address = \"${IP_ADDRESS}\"" \
-         | jq ".server.ucs.host = \"${IP_ADDRESS}\"" \
-         | tee ~/server/eqemu_config.json
+    		| jq '.server.database.password = "${EQEMU_DB_PASSWORD}"' \
+    		| jq '.server.world.key = "$(shell cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w $${1:-32} | head -n 1)"' \
+    		| jq '.server.zones.ports.high = "${PORT_RANGE_HIGH}"' \
+    		| jq '.server.world.address = "${IP_ADDRESS}"' \
+    		| jq '.server.ucs.host = "${IP_ADDRESS}"' \
+    		-M > ~/server/eqemu_config.json
 
 init-directories: ##@init Bootstrap directories
 	@./assets/scripts/banner.pl "Bootstrapping directories"
@@ -165,7 +165,7 @@ init-eqemu-admin: ##@init Initializes EQEmu Admin
 		| jq '.["web-admin"].launcher.runSharedMemory = true' \
 		| jq '.["web-admin"].launcher.minZoneProcesses = 10' \
 		| jq '.["web-admin"].launcher.staticZones = "butcher,erudnext,freporte,qeynos,freeporte,oot,iceclad,nro,oasis,nedaria,abysmal,natimbi,timorous,abysmal,firiona,overthere"' \
-		| tee ~/server/eqemu_config.json
+		-M > ~/server/eqemu_config.json
 	cd ~/server && ./bin/spire spire:init admin ${ADMIN_PASSWORD} || echo "Already initialized"
 	cd ~/server && ./bin/spire spire:occulus-update
 

--- a/assets/scripts/Makefile
+++ b/assets/scripts/Makefile
@@ -90,7 +90,7 @@ init-eqemu-config: ##@init Bootstraps eqemu config
              | jq --arg ipaddr "$(IP_ADDRESS)" '.server.world.address = $$ipaddr | .server.ucs.host = $$ipaddr' \
              | jq --arg porthigh "$(PORT_RANGE_HIGH)" '.server.zones.ports.high = $$porthigh' \
              | jq --arg random_string "$$(openssl rand -base64 32 | tr -dc 'a-zA-Z0-9' | head -c 32)" '.server.world.key = $$random_string' \
-             -M > /tmp/config.json && mv /tmp/config.json ~/server/eqemu_config.json
+             -M > /tmp/config.json && mv /tmp/config.json ~/server/eqemu_config.json && rm -f /tmp/config.json
 
 init-directories: ##@init Bootstrap directories
 	@./assets/scripts/banner.pl "Bootstrapping directories"
@@ -164,7 +164,7 @@ init-eqemu-admin: ##@init Initializes EQEmu Admin
 		| jq '.["web-admin"].launcher.runSharedMemory = true' \
 		| jq '.["web-admin"].launcher.minZoneProcesses = 10' \
 		| jq '.["web-admin"].launcher.staticZones = "butcher,erudnext,freporte,qeynos,freeporte,oot,iceclad,nro,oasis,nedaria,abysmal,natimbi,timorous,abysmal,firiona,overthere"' \
-		| tee ~/server/eqemu_config.json
+		-M > /tmp/config.json && mv /tmp/config.json ~/server/eqemu_config.json && rm -f /tmp/config.json
 	cd ~/server && ./bin/spire spire:init admin ${ADMIN_PASSWORD} || echo "Already initialized"
 	cd ~/server && ./bin/spire spire:occulus-update
 

--- a/assets/scripts/Makefile
+++ b/assets/scripts/Makefile
@@ -88,10 +88,10 @@ init-eqemu-config: ##@init Bootstraps eqemu config
 	jq --arg dbpass "$(EQEMU_DB_PASSWORD)" \
 	   --arg porthigh "$(PORT_RANGE_HIGH)" \
 	   --arg ipaddr "$(IP_ADDRESS)" \
-	   '.server.database.password = $$dbpass |
-		.server.world.key = (input_filename | capture("(?<prefix>.*)(?<suffix>.json)"; "i").prefix + ("/dev/urandom" | getline | strflocaltime("%Y%m%d%H%M%S"))) |
-		.server.zones.ports.high = $$porthigh |
-		.server.world.address = $$ipaddr |
+	   '.server.database.password = $$dbpass | \
+		.server.world.key = (input_filename | capture("(?<prefix>.*)(?<suffix>.json)"; "i").prefix + ("/dev/urandom" | getline | strflocaltime("%Y%m%d%H%M%S"))) | \
+		.server.zones.ports.high = $$porthigh | \
+		.server.world.address = $$ipaddr | \
         .server.ucs.host = $ipaddr' ~/server/eqemu_config.json > temp.json && mv temp.json ~/server/eqemu_config.json
 
 init-directories: ##@init Bootstrap directories

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ networks:
 
 volumes:
   build-cache:
+  spire-assets:
 
 services:
 
@@ -21,6 +22,7 @@ services:
       - ./code:/home/eqemu/code:delegated
       - ./assets:/home/eqemu/assets:delegated
       - build-cache:/home/eqemu/.ccache/
+      - spire-assets:/home/eqemu/.cache/
     ports:
       - ${IP_ADDRESS}:2222:22/tcp
       - ${IP_ADDRESS}:2222:22/udp


### PR DESCRIPTION
**Changes**

* Add a volume for Spire admin assets so they persist through reboots ~/.cache/
* Chown ~/.cache/ during install to `eqemu` user
* Changed the way `jq` pipes to config files to be more resilient under certain environments
* Change `wget` to use a simpler less noisy progress method 
* Use `make down` and `make up` at the end of the `make install` routine