### PR TITLE
Release build to mirror CI build

### DIFF
--- a/assets/scripts/Makefile
+++ b/assets/scripts/Makefile
@@ -277,6 +277,24 @@ init-build: ##@build Initialize build
 			-DPERL_INCLUDE_PATH=/opt/eqemu-perl/lib/5.32.1/x86_64-linux-thread-multi/CORE/ \
 			-DCMAKE_CXX_FLAGS_RELWITHDEBINFO:STRING="-O1 -g -DNDEBUG -Wno-everything" \
 			-DCMAKE_CXX_COMPILER_LAUNCHER=ccache -G 'Unix Makefiles' ..
+init-release-build:
+	@./assets/scripts/banner.pl "Initializing EQEmu Server Release Build"
+	cd ~/code && \
+		git submodule init && \
+		git submodule update && \
+		rm -rf build && \
+		mkdir -p build && \
+		cd build && \
+		cmake \
+			-DEQEMU_BUILD_TESTS=ON \
+			-DEQEMU_BUILD_STATIC=ON \
+			-DEQEMU_BUILD_LOGIN=ON \
+			-DEQEMU_BUILD_LUA=ON \
+			-DEQEMU_BUILD_PERL=ON \
+			-DCMAKE_CXX_FLAGS:STRING="-O1 -g -Wno-everything" \
+			-DCMAKE_CXX_FLAGS_RELWITHDEBINFO:STRING="-O1 -g -Wno-everything" \
+			-DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+			-G 'Unix Makefiles' ..
 
 init-dev-build: ##@build Initialize build for development (faster compiles, uses ninja)
 	@./assets/scripts/banner.pl "Initializing EQEmu Server Build"


### PR DESCRIPTION
This adds an option to create a release build that mirrors what is in the linux-build.sh script. Notably with static linkage to prevent a memory leak from lua using dynamic libs, which could be investigated and fixed independently, but also to offer an option to create binaries the way CI is.