### PR TITLE
[Backups] Player hourly snapshots

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,3 +89,5 @@ TZ=US/Central
 # BACKUP_RETENTION_DAYS_DB_SNAPSHOTS=10
 # BACKUP_RETENTION_DAYS_DEPLOYMENT=35
 # BACKUP_RETENTION_DAYS_QUEST_SNAPSHOTS=7
+# Below is two days worth of hourly snapshots (if this isn't set, the hourly snapshots will be disabled)
+# BACKUP_RETENTION_HOURLY_PLAYER_DB_SNAPSHOTS=48

--- a/backup/backup-database-hourly-player-tables.sh
+++ b/backup/backup-database-hourly-player-tables.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# Fetch hostname deployment directory and format into backup prepend
+# DEPLOYMENT_NAME=$HOST_NAME/$(basename $HOST_DIR)
+
+CWD=$(pwd)
+source $CWD/.env
+
+export TZ
+
+if [ -z "${BACKUP_RETENTION_HOURLY_PLAYER_DB_SNAPSHOTS}" ]; then
+  echo "Error: BACKUP_RETENTION_HOURLY_PLAYER_DB_SNAPSHOTS is not set. Exiting."
+  exit 1
+fi
+
+# get player tables from github, we can't hit world from the backup-cron container without duplicating the eqemu-server container and its dependencies
+player_tables=$(curl -s "https://raw.githubusercontent.com/EQEmu/Server/refs/heads/master/common/database_schema.h" | \
+awk '/GetPlayerTables\(\)/,/\}/' | \
+grep -oP '"\K[^"]+' | \
+tr '\n' ' ' | sed 's/,//g' | xargs)
+
+cd /tmp/
+
+# validate
+set -e
+"$CWD/backup/validate-dropbox.sh"
+set +e
+
+#############################################
+# mysqldump
+#############################################
+echo "# Dumping database and compressing"
+MYSQL_BACKUP_NAME=${MARIADB_DATABASE}-player-data-$(date +"%m-%d-%Y_h%H-m%M")
+mysqldump --lock-tables=false -u${MARIADB_USER} -p${MARIADB_PASSWORD} -h mariadb ${MARIADB_DATABASE} ${player_tables} >/tmp/${MYSQL_BACKUP_NAME}.sql
+tar -zcvf ${MYSQL_BACKUP_NAME}.tar.gz ${MYSQL_BACKUP_NAME}.sql
+
+#############################################
+# upload
+#############################################
+echo "# Uploading database snapshot"
+dropbox_uploader.sh upload ${MYSQL_BACKUP_NAME}.tar.gz ${DEPLOYMENT_NAME:-backups}/database-player-hourly-snapshots/${MYSQL_BACKUP_NAME}.tar.gz
+
+#############################################
+# prune snapshots
+#############################################
+BACKUP_RETENTION=${BACKUP_RETENTION_HOURLY_PLAYER_DB_SNAPSHOTS:-48}
+BACKUP_PATH=${DEPLOYMENT_NAME:-backups}/database-player-hourly-snapshots
+echo "# Truncating ${BACKUP_PATH} hours back ${BACKUP_RETENTION}"
+OUTPUT=$($CWD/backup/dropbox-list-truncation-files-hourly.pl ${BACKUP_PATH} ${BACKUP_RETENTION})
+for x in $OUTPUT; do dropbox_uploader.sh delete ${BACKUP_PATH}/$x; done
+
+#############################################
+# cleanup
+#############################################
+echo "# Cleaning up..."
+sudo rm -rf /tmp/${MYSQL_BACKUP_NAME}.*

--- a/backup/backup-database.sh
+++ b/backup/backup-database.sh
@@ -6,6 +6,8 @@
 CWD=$(pwd)
 source $CWD/.env
 
+export TZ
+
 cd /tmp/
 
 # validate

--- a/backup/backup-deployment.sh
+++ b/backup/backup-deployment.sh
@@ -6,6 +6,8 @@
 CWD=$(pwd)
 source $CWD/.env
 
+export TZ
+
 cd /tmp/
 
 # validate

--- a/backup/backup-quests.sh
+++ b/backup/backup-quests.sh
@@ -6,6 +6,8 @@
 CWD=$(pwd)
 source $CWD/.env
 
+export TZ
+
 cd /tmp/
 
 # validate

--- a/backup/crontab.cron
+++ b/backup/crontab.cron
@@ -9,6 +9,9 @@ MAILTO=""
 # once a day on a random variance to keep from bursting backups amongst several servers
 0 1 * * * perl -e 'sleep int(rand(1800))'; ./backup/backup-database.sh > /dev/null
 
+# once an hour
+@hourly cd /home/backup-cron && ./backup/backup-database-hourly-player-tables.sh > /dev/null
+
 # once a day on a random variance to keep from bursting backups amongst several servers
 0 1 * * * perl -e 'sleep int(rand(1800))'; ./backup/backup-quests.sh > /dev/null
 

--- a/backup/dropbox-list-truncation-files-hourly.pl
+++ b/backup/dropbox-list-truncation-files-hourly.pl
@@ -1,0 +1,56 @@
+#!/usr/bin/perl
+
+my $dropbox_list_path       = $ARGV[0];
+my $truncate_keep_days_back = $ARGV[1];
+
+if (!$dropbox_list_path || !$truncate_keep_days_back) {
+    print "Example [list_path] [keep_days_back]\n\n";
+}
+
+my $output = `dropbox_uploader.sh list $dropbox_list_path`;
+my @lines  = split("\n", $output);
+my %files  = ();
+foreach my $line (@lines) {
+    if ($line =~ /\[F]/i) {
+        my @columns = split(" ", $line);
+        my $date_column = trim($columns[2]);
+
+        # Use regex to capture MM-DD-YYYY_hHH-mMM
+        if ($date_column =~ /(\d{2})-(\d{2})-(\d{4})_h(\d{2})-m(\d{2})/) {
+            my $month = $1;
+            my $day = $2;
+            my $year = $3;
+            my $hour = $4;
+            my $minute = $5;
+
+            # Generate UNIX time from date and time components
+            my $unix_time = trim(`date -d "$year-$month-$day $hour:$minute:00" +%s`);
+            $files{$unix_time} = trim($date_column);
+        }
+    }
+}
+
+# print "# Files\n";
+my @files_to_truncate = ();
+my $index = 0;
+foreach my $key (reverse sort keys %files) {
+    # print "[" . $key . "] [" . $files{$key} . "]\n";
+    if ($index >= $truncate_keep_days_back) {
+        push (@files_to_truncate, $files{$key});
+    }
+    else {
+        # print "Not deleting [" . $files{$key} . "] ($index) \n";
+    }
+    $index++;
+}
+
+foreach my $file (@files_to_truncate) {
+    print $file . "\n";
+}
+
+sub trim {
+    my $string = $_[0];
+    $string =~ s/^\s+//;
+    $string =~ s/\s+$//;
+    return $string;
+}

--- a/containers/backup-cron/Dockerfile
+++ b/containers/backup-cron/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10-slim
+FROM debian:12-slim
 
 ARG PUID=1000
 ENV PUID ${PUID}
@@ -13,8 +13,11 @@ RUN apt-get update -yqq && \
 RUN apt-get update && apt-get install -y \
     bash \
     curl \
+    jq \
     cron \
+    libssl-dev \
     make \
+    tzdata \
     sudo \
     inotify-tools \
     mariadb-client \


### PR DESCRIPTION
This is a request I've had for snapshotting player tables at a more regular interval for data retention. This is a "for-now" option until all backups are managed natively through Spire using https://rclone.org/

This is enabled when you configure the following envrionment variable in your `.env`

For now this fetches its player table source from https://raw.githubusercontent.com/EQEmu/Server/refs/heads/master/common/database_schema.h because the `backup-cron` container cannot run binaries directly. When this is all managed in Spire Admin natively, there will be no issue fetching the schema truth from the world binary.

```bash
BACKUP_RETENTION_HOURLY_PLAYER_DB_SNAPSHOTS=48
```

## Testing

Below are 48 snapshots, they are per-minute snapshots from testing but under normal circumstances they would be per-hour.

![image](https://github.com/user-attachments/assets/4a234093-89bd-4c5e-81c3-628337ebcf80)

**Output**

```bash
# Dumping database and compressing
peq-player-data-11-14-2024_h17-m51.sql
# Uploading database snapshot
 > Uploading "/tmp/peq-player-data-11-14-2024_h17-m51.tar.gz" to "/backups/database-player-hourly-snapshots/peq-player-data-11-14-2024_h17-m51.tar.gz"... DONE
# Truncating backups/database-player-hourly-snapshots hours back 48
 > Deleting "/backups/database-player-hourly-snapshots/peq-player-data-11-14-2024_h17-m12.tar.gz"... DONE
# Cleaning up...
```